### PR TITLE
WL-2088/WL-2409 : add sso username as custom launch data

### DIFF
--- a/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -415,6 +415,10 @@ public class SakaiBLTIUtil {
 				setProperty(props,BasicLTIConstants.LIS_PERSON_CONTACT_EMAIL_PRIMARY,user.getEmail());
 				setProperty(props,BasicLTIConstants.LIS_PERSON_SOURCEDID,user.getEid());
 				setProperty(props,"ext_sakai_eid",user.getEid());
+				// Only send the display ID if it's different to the EID.
+				if (!user.getEid().equals(user.getDisplayId())) {
+					setProperty(props,BasicLTIConstants.EXT_SAKAI_PROVIDER_DISPLAYID,user.getDisplayId());
+				}
 			}
 
 			String assignment = null;


### PR DESCRIPTION
This was part of 2.8 codebase and not put into 10.

It's logic that's on LIVE to say that we should send the SSO username (displayId) to LTI (if it's different to the login ID).
