### PR TITLE
WL-3652 Prevent NPE when anon user is accessing tool.

### DIFF
--- a/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -416,7 +416,8 @@ public class SakaiBLTIUtil {
 				setProperty(props,BasicLTIConstants.LIS_PERSON_SOURCEDID,user.getEid());
 				setProperty(props,"ext_sakai_eid",user.getEid());
 				// Only send the display ID if it's different to the EID.
-				if (!user.getEid().equals(user.getDisplayId())) {
+				// the anonymous user has a null EID.
+				if (user.getEid() != null && !user.getEid().equals(user.getDisplayId())) {
 					setProperty(props,BasicLTIConstants.EXT_SAKAI_PROVIDER_DISPLAYID,user.getDisplayId());
 				}
 			}


### PR DESCRIPTION
The anon user doesn’t have an EID so this NPEs.
