### PR TITLE
WL-3705 Basic LTI tool pop-option works correctly.

### DIFF
--- a/basiclti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
+++ b/basiclti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
@@ -288,7 +288,12 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 			contentModelList.add(LTI_RESOURCE_HANDLER + ":text");
 			contentModel = contentModelList.toArray(new String[contentModelList.size()]);
 		}
-		
+		//If newpage(pop-up launch) is not in content and is in the tool, copy it, needed for 'always launch in pop-up option'
+		if( newProps.getProperty(LTI_NEWPAGE) == null && tool.get(LTI_NEWPAGE) != null){
+			newProps.put(LTI_NEWPAGE, String.valueOf(tool.get(LTI_NEWPAGE)));
+			contentModelList.add(LTI_NEWPAGE + ":checkbox:label=bl_newpage");
+			contentModel = contentModelList.toArray(new String[contentModelList.size()]);
+		}
 		if (contentModel == null)
 			return rb.getString("error.invalid.toolid");
 		return insertThingDao("lti_content", contentModel, LTIService.CONTENT_MODEL, newProps, siteId, isAdminRole, isMaintainRole);


### PR DESCRIPTION
Checking for the 'Always add pop-option' in the content and tool and
setting accordingly in the 'contentModel'.
