### PR TITLE
WL-3705 Just tool in the tool for the popup value.

### DIFF
--- a/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -1356,10 +1356,7 @@ public class SakaiBLTIUtil {
 			if ( tool == null ) return null;
 
 			// Adjust the content items based on the tool items
-			if ( tool != null || content != null )
-			{
-				ltiService.filterContent(content, tool);
-			}
+			ltiService.filterContent(content, tool);
 
 			for (String formInput : LTIService.TOOL_MODEL) {
 				Properties info = parseFormString(formInput);

--- a/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/BasicLTISecurityServiceImpl.java
+++ b/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/BasicLTISecurityServiceImpl.java
@@ -335,10 +335,7 @@ public class BasicLTISecurityServiceImpl implements EntityProducer {
 								   }
 
 								   // Adjust the content items based on the tool items
-								   if ( tool != null || content != null ) 
-								   {
-									   ltiService.filterContent(content, tool);
-								   }
+									ltiService.filterContent(content, tool);
 							   }
 							   String splash = null;
 							   if ( tool != null ) splash = (String) tool.get("splash");

--- a/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -484,14 +484,13 @@ public abstract class BaseLTIService implements LTIService {
 			frameHeight = contentHeight;
 		content.put(LTIService.LTI_FRAMEHEIGHT, new Integer(frameHeight));
 
-		Integer newProp = null;
-		newProp = getCorrectProperty("debug", content, tool);
-		if (newProp != null)
-			content.put("debug", newProp);
+		int debug = getInt(tool.get(LTIService.LTI_DEBUG));
+		if ( debug == 2 ) debug = getInt(content.get(LTIService.LTI_DEBUG));
+		content.put(LTIService.LTI_DEBUG, debug+"");
 
-		newProp = getCorrectProperty(LTIService.LTI_NEWPAGE, content, tool);
-		if (newProp != null)
-			content.put(LTIService.LTI_NEWPAGE, newProp);
+		int newpage = getInt(tool.get(LTIService.LTI_NEWPAGE));
+		if ( newpage == 2 ) newpage = getInt(content.get(LTIService.LTI_NEWPAGE));
+		content.put(LTIService.LTI_NEWPAGE, newpage+"");
 	}
 
 	/**

--- a/basiclti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
+++ b/basiclti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
@@ -288,7 +288,6 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 			contentModelList.add(LTI_RESOURCE_HANDLER + ":text");
 			contentModel = contentModelList.toArray(new String[contentModelList.size()]);
 		}
-		
 		if (contentModel == null)
 			return rb.getString("error.invalid.toolid");
 		return insertThingDao("lti_content", contentModel, LTIService.CONTENT_MODEL, newProps, siteId, isAdminRole, isMaintainRole);

--- a/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
+++ b/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
@@ -212,20 +212,20 @@ public class SakaiIFrame extends GenericPortlet {
 			}
 			try {
 				content = m_ltiService.getContent(key);
+				Long tool_id = getLongNull(content.get("tool_id"));
 				// If we are supposed to popup (per the content), do so and optionally
 				// copy the calue into the placement to communicate with the portal
-				popup = getLongNull(content.get("newpage")) == 1;
+				if (tool_id != null) {
+					tool = m_ltiService.getTool(tool_id);
+					m_ltiService.filterContent(content, tool);
+				}
+				Object popupValue = content.get("newpage");
+				popup = getLongNull(popupValue) == 1;
 				if ( oldPopup != popup ) {
 					placement.getPlacementConfig().setProperty(POPUP, popup ? "true" : "false");
 					placement.save();
 				}
 				String launch = (String) content.get("launch");
-				Long tool_id = getLongNull(content.get("tool_id"));
-				if ( launch == null && tool_id != null ) {
-					tool = m_ltiService.getTool(tool_id);
-					launch = (String) tool.get("launch");
-				}
-
 				// Force http:// to pop-up if we are https://
 				String serverUrl = ServerConfigurationService.getServerUrl();
 				if ( request.isSecure() || ( serverUrl != null && serverUrl.startsWith("https://") ) ) {


### PR DESCRIPTION
This means that when someone changes the popup value in a systemwide tool it won’t change straight away, but only after someone uses the LTI tool in a site. It’s not very nice but it’s the smallest fix.

The larger fix would have been to either to completely re-architect how LTI registers tools (not practical) or to have a DB job to change all uses of the tool when a change was made. This would have been possible but it’s a different style to how the rest of the LTI tool works.
